### PR TITLE
Changed width to fit content

### DIFF
--- a/index.css
+++ b/index.css
@@ -1,7 +1,7 @@
 body
 {
     background: white;
-    width: 200px;
+    width: fit-content;
     display: block;
     margin: 20 auto;
 }


### PR DESCRIPTION
Body's width was slightly too large so the display was longer than the calculator's buttons. This was fixed by changing the width to fit content.